### PR TITLE
fix: replace hero image with hero4.png + fix jitter/performance

### DIFF
--- a/src/app/Hero/Page.jsx
+++ b/src/app/Hero/Page.jsx
@@ -4,36 +4,37 @@ const Page = () => {
   return (
     <section id="hero" className="relative w-full">
       {/*
-        Hero covers the dynamic viewport (100dvh) to avoid mobile UI clipping.
-        On phones, we prefer "contain" so the full artwork is visible (no cropping).
-        On md+ screens, we switch to "cover" for an edge-to-edge look.
+        Mobile: container matches the image's native aspect ratio (1280×836)
+        so it fills perfectly — no cropping, no margins.
+        Desktop: full-viewport (100dvh) with cover for edge-to-edge.
       */}
-  <div className="relative z-[100000] w-full min-h-[100dvh] h-[100dvh] overflow-hidden bg-transparent">
-        <div className="relative w-full h-full">
-          {/* Mobile (default): show full image */}
-          <div className="relative w-full h-full md:hidden">
-            <Image
-              src="/images/hero1.png"
-              alt="Hero"
-              fill
-              priority
-              style={{ objectFit: "contain", objectPosition: "50% 60%" }}
-              sizes="100vw"
-            />
-          </div>
 
-          {/* Desktop/tablet: fill viewport */}
-          <div className="relative w-full h-full hidden md:block">
-            <Image
-              src="/images/hero1.png"
-              alt="Hero"
-              fill
-              priority
-              style={{ objectFit: "cover", objectPosition: "50% 60%" }}
-              sizes="(min-width: 768px) 100vw"
-            />
-          </div>
+      {/* Mobile: vertically centered, aspect-ratio container */}
+      <div className="relative z-[100000] w-full min-h-[100dvh] flex items-center md:hidden bg-transparent">
+        <div className="relative w-full" style={{ aspectRatio: '1280 / 836' }}>
+          <Image
+            src="/images/hero4.png"
+            alt="Hero"
+            fill
+            priority
+            quality={90}
+            style={{ objectFit: "fill" }}
+            sizes="100vw"
+          />
         </div>
+      </div>
+
+      {/* Desktop/tablet: full viewport height with cover */}
+      <div className="relative z-[100000] w-full min-h-[100dvh] h-[100dvh] overflow-hidden bg-transparent hidden md:block">
+        <Image
+          src="/images/hero4.png"
+          alt="Hero"
+          fill
+          priority
+          quality={90}
+          style={{ objectFit: "cover", objectPosition: "center center" }}
+          sizes="(min-width: 768px) 100vw"
+        />
       </div>
     </section>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,11 @@ h1{
   font-family: "Kalamayka", sans-serif;
 }
 
+html {
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
 body{
   /* background-image: url("/images/bg.jpg"); */
   background-color: black !important;
@@ -87,16 +92,18 @@ body{
   text-shadow: none;
 }
 
-/* global.css */
+/* ── video-background (single canonical definition) ────────────── */
 .video-background {
-  opacity: 20%;
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
+  object-fit: cover;
   overflow: hidden;
-  z-index: -1;
+  z-index: -10;
+  opacity: 0.2;
+  will-change: transform;
 }
 
 @import url("https://fonts.cdnfonts.com/css/general-sans");
@@ -380,81 +387,20 @@ body {
     opacity: 0.8;
   }
 }
-.video-background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-body {
-  background-color: none !important;
-}
-.video-background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  z-index: -1; /* Ensures the video is behind the content */
-}
-
-.video-background {
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: position 0.3s ease; /* Smooth transition */
-}
-
 .video-background.absolute {
   position: absolute;
 }
 
 .video-background.fixed {
   position: fixed;
-  z-index: -1; /* Keeps the video behind other content */
+  z-index: -1;
 }
 
-/*
-  Mobile behavior:
-  - Keep the background video enabled only while the hero is on screen.
-  - Disable it for the rest of the page for performance.
-
-  Note: `#hero` exists on the homepage hero section.
-*/
 @media (max-width: 1023px) {
-  /* Mobile: keep the video visible across the full page */
   .video-background {
     display: block !important;
-    opacity: 0.18; /* lighter on mobile for readability */
+    opacity: 0.18;
   }
-}
-
-/* Ensure background sits behind content by using negative z-index via utility in markup, but keep a sane default here */
-.video-background {
-  z-index: -10;
-}
-.video-background {
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: position 0.3s ease; /* Smooth transition */
-}
-
-.video-background.absolute {
-  position: absolute;
-}
-
-.video-background.fixed {
-  position: fixed;
-  z-index: -1; /* Keeps the video behind other content */
 }
 
 /*---break---*/

--- a/src/components/ui/animated-shader-background.tsx
+++ b/src/components/ui/animated-shader-background.tsx
@@ -24,7 +24,7 @@ const AnoAI = () => {
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     const renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: 'low-power' });
 
-  const getDpr = () => Math.min(window.devicePixelRatio || 1, isMobile || isLowPower ? 1.0 : 1.5);
+    const getDpr = () => Math.min(window.devicePixelRatio || 1, isMobile || isLowPower ? 1.0 : 1.5);
     renderer.setPixelRatio(getDpr());
     renderer.setSize(window.innerWidth, window.innerHeight, false);
     container.appendChild(renderer.domElement);
@@ -33,7 +33,7 @@ const AnoAI = () => {
       uniforms: {
         iTime: { value: 0 },
         iResolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
-  iQuality: { value: isMobile ? 0.45 : isLowPower ? 0.7 : 1.0 },
+        iQuality: { value: isMobile ? 0.45 : isLowPower ? 0.7 : 1.0 },
       },
       vertexShader: `
         void main() {
@@ -115,8 +115,8 @@ const AnoAI = () => {
     let frameId: number | undefined;
     let last = 0;
     let paused = false;
-  const targetFps = isMobile ? 28 : isLowPower ? 32 : 45;
-  const targetFrameMs = 1000 / targetFps;
+    const targetFps = isMobile ? 28 : isLowPower ? 32 : 45;
+    const targetFrameMs = 1000 / targetFps;
 
     const renderOnce = () => {
       renderer.render(scene, camera);
@@ -142,12 +142,16 @@ const AnoAI = () => {
       });
     }
 
+    let resizeRaf = 0;
     const handleResize = () => {
-      renderer.setPixelRatio(getDpr());
-      renderer.setSize(window.innerWidth, window.innerHeight, false);
-      material.uniforms.iResolution.value.set(window.innerWidth, window.innerHeight);
-
-      if (reduceMotion) renderOnce();
+      if (resizeRaf) return;
+      resizeRaf = requestAnimationFrame(() => {
+        resizeRaf = 0;
+        renderer.setPixelRatio(getDpr());
+        renderer.setSize(window.innerWidth, window.innerHeight, false);
+        material.uniforms.iResolution.value.set(window.innerWidth, window.innerHeight);
+        if (reduceMotion) renderOnce();
+      });
     };
     window.addEventListener('resize', handleResize);
 
@@ -177,12 +181,13 @@ const AnoAI = () => {
             animate(now);
           });
         }
-      }, 150);
+      }, 200);
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
       if (typeof frameId === 'number') cancelAnimationFrame(frameId);
+      if (resizeRaf) cancelAnimationFrame(resizeRaf);
       window.removeEventListener('resize', handleResize);
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('scroll', handleScroll);

--- a/src/components/ui/smooth-cursor.tsx
+++ b/src/components/ui/smooth-cursor.tsx
@@ -125,6 +125,8 @@ export function SmoothCursor({
       lastMousePos.current = currentPos;
     };
 
+    let moveTimeout: ReturnType<typeof setTimeout> | null = null;
+
     const smoothMouseMove = (e: MouseEvent) => {
       const currentPos = { x: e.clientX, y: e.clientY };
       updateVelocity(currentPos);
@@ -151,12 +153,12 @@ export function SmoothCursor({
         scale.set(0.95);
         setIsMoving(true);
 
-        const timeout = setTimeout(() => {
+        // Clear any previous timeout to prevent timer accumulation & jank
+        if (moveTimeout) clearTimeout(moveTimeout);
+        moveTimeout = setTimeout(() => {
           scale.set(1);
           setIsMoving(false);
         }, 150);
-
-        return () => clearTimeout(timeout);
       }
     };
 
@@ -177,6 +179,7 @@ export function SmoothCursor({
       window.removeEventListener("mousemove", throttledMouseMove);
       document.body.style.cursor = "auto";
       if (rafId) cancelAnimationFrame(rafId);
+      if (moveTimeout) clearTimeout(moveTimeout);
     };
   }, [cursorX, cursorY, rotation, scale]);
 


### PR DESCRIPTION
## Changes

### Hero Image
- Replace hero1.png → hero4.png with responsive layout
- Mobile: aspect-ratio container + vertical centering (no crop/margin)
- Desktop: full-viewport cover for edge-to-edge display

### Performance & Smoothness
- Deduplicate `.video-background` CSS (4 duplicate blocks → 1)
- Remove un-transitionable `transition: position` causing layout thrash
- Add smooth-scroll + GPU acceleration hints
- Debounce shader resize handler with requestAnimationFrame
- Extend mobile scroll-pause timeout (150→200ms) for smoother transitions
- Fix smooth-cursor setTimeout leak causing micro-jank from accumulated timers

### Files Changed
- `src/app/Hero/Page.jsx`
- `src/app/globals.css`
- `src/components/ui/animated-shader-background.tsx`
- `src/components/ui/smooth-cursor.tsx`